### PR TITLE
feat: allow graphql endpoint to be configurable

### DIFF
--- a/src/client/getClient.ts
+++ b/src/client/getClient.ts
@@ -23,7 +23,7 @@ export const getClient = ({
   token: Token,
   version,
 }: ClientOptions) =>
-  new GraphQLClient('https://gapi.storyblok.com/v1/api', {
+  new GraphQLClient(process.env.NEXT_PUBLIC_STORYBLOK_ENDPOINT ? process.env.NEXT_PUBLIC_STORYBLOK_ENDPOINT : 'https://gapi.storyblok.com/v1/api', {
     ...(additionalOptions || {}),
     headers: {
       Token,

--- a/src/client/getClient.ts
+++ b/src/client/getClient.ts
@@ -1,6 +1,12 @@
 import { GraphQLClient } from 'graphql-request';
 
 export interface ClientOptions {
+  /**   
+   * Which GraphQL endpoint to use (override default endpoint).
+   *
+   * @default 'https://gapi.storyblok.com/v1/api'
+   **/  
+   endpoint?: string;
   /**
    * Custom fetch init parameters, `graphql-request` version.
    *
@@ -19,11 +25,12 @@ export interface ClientOptions {
 }
 
 export const getClient = ({
+  endpoint,
   additionalOptions,
   token: Token,
   version,
 }: ClientOptions) =>
-  new GraphQLClient(process.env.NEXT_PUBLIC_STORYBLOK_ENDPOINT ? process.env.NEXT_PUBLIC_STORYBLOK_ENDPOINT : 'https://gapi.storyblok.com/v1/api', {
+  new GraphQLClient(endpoint ?? 'https://gapi.storyblok.com/v1/api', {
     ...(additionalOptions || {}),
     headers: {
       Token,

--- a/website/docs/api/getClient.md
+++ b/website/docs/api/getClient.md
@@ -18,6 +18,12 @@ This function expects the dependencies `graphql-request` and `graphql` to be ins
 ```ts no-transpile
 interface ClientOptions {
   /**
+   * Which GraphQL endpoint to use (override default endpoint).
+   *
+   * @default 'https://gapi.storyblok.com/v1/api'
+   **/
+   endpoint?: string;
+  /**
    * Custom fetch init parameters, `graphql-request` version.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters


### PR DESCRIPTION
As per #4 we would like to add an option to override the Storyblok API endpoint.