### PR TITLE
refactor(image): placeholder in safari reader mode

### DIFF
--- a/src/image/Image.tsx
+++ b/src/image/Image.tsx
@@ -51,13 +51,16 @@ export const Image = ({
   fluid,
   height,
   onLoad: onLoadProp,
-  showPlaceholder = true,
+  showPlaceholder: initShowPlaceholder = true,
   smart,
   width,
   ref,
   ...props
 }: ImageProps) => {
   const [isLoading, setLoading] = React.useState(props.lazy === false);
+  const [showPlaceholder, setShowPlaceholder] = React.useState(
+    initShowPlaceholder,
+  );
   const { onLoad, isLoaded, setLoaded } = useImageLoader(onLoadProp);
   const imgRef = React.useRef<HTMLImageElement>();
   const observer = useRef<IntersectionObserver>();
@@ -133,7 +136,11 @@ export const Image = ({
       />
 
       {showPlaceholder && (
-        <Placeholder src={props.src} shouldShow={!isLoaded} />
+        <Placeholder
+          src={props.src}
+          shouldShow={!isLoaded}
+          onFadeEnd={setShowPlaceholder}
+        />
       )}
 
       <Picture

--- a/src/image/Placeholder.tsx
+++ b/src/image/Placeholder.tsx
@@ -26,6 +26,7 @@ export const Placeholder = ({
     <img
       {...props}
       style={{
+        display: shouldShow ? '' : 'none',
         position: 'absolute',
         top: '0px',
         left: '0px',

--- a/src/image/Placeholder.tsx
+++ b/src/image/Placeholder.tsx
@@ -3,45 +3,44 @@ import React from 'react';
 interface PlaceholderProps {
   src: string;
   shouldShow?: boolean;
+  onFadeEnd?(visible: boolean): void;
 }
 
 export const Placeholder = ({
   shouldShow,
   src,
+  onFadeEnd,
   ...props
 }: PlaceholderProps) => {
   const imageService = '//img2.storyblok.com';
   const path = src.replace('//a.storyblok.com', '').replace('https:', '');
   const blurredSrc = `${imageService}/32x0/filters:blur(10)${path}`;
 
+  const handleTransitionEnd = () => {
+    if (onFadeEnd) {
+      onFadeEnd(shouldShow);
+    }
+  };
+
   return (
-    <div
-      hidden
+    <img
+      {...props}
       style={{
-        display: 'block',
         position: 'absolute',
         top: '0px',
         left: '0px',
         width: '100%',
         height: '100%',
+        objectFit: 'cover',
+        objectPosition: 'center center',
+        transition: 'opacity 500ms linear',
+        opacity: shouldShow ? 1 : 0,
       }}
-    >
-      <img
-        {...props}
-        style={{
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-          objectPosition: 'center center',
-          transition: 'opacity 500ms linear',
-          opacity: shouldShow ? 1 : 0,
-        }}
-        alt=""
-        aria-hidden
-        role="presentation"
-        decoding="async"
-        src={blurredSrc}
-      />
-    </div>
+      alt=""
+      role="presentation"
+      decoding="async"
+      src={blurredSrc}
+      onTransitionEnd={handleTransitionEnd}
+    />
   );
 };

--- a/src/image/__tests__/Placeholder.test.tsx
+++ b/src/image/__tests__/Placeholder.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+
+import { Placeholder } from '../Placeholder';
+
+const storyblokImage =
+  'https://a.storyblok.com/f/39898/3310x2192/e4ec08624e/demo-image.jpeg';
+
+describe('[image] Placeholder', () => {
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  it('should use src prop', async () => {
+    const { getByTestId } = render(
+      <Placeholder data-testid="img" src={storyblokImage} />,
+    );
+    const image = getByTestId('img');
+
+    expect(image).toHaveAttribute('src');
+  });
+
+  it('should be visible when `shouldShow` is true', async () => {
+    const { getByTestId } = render(
+      <Placeholder data-testid="img" src={storyblokImage} shouldShow />,
+    );
+    const image = getByTestId('img');
+    const styles = getComputedStyle(image);
+
+    expect(styles).toHaveProperty('opacity', '1');
+  });
+
+  it('should not be visible when `shouldShow` is false', async () => {
+    const { getByTestId } = render(
+      <Placeholder data-testid="img" src={storyblokImage} shouldShow />,
+    );
+    const image = getByTestId('img');
+    const styles = getComputedStyle(image);
+
+    expect(styles).toHaveProperty('opacity', '1');
+  });
+
+  it('should call `onFadeEnd` when transition ended', async () => {
+    const mock = jest.fn();
+    const { getByTestId, rerender } = render(
+      <Placeholder
+        data-testid="img"
+        src={storyblokImage}
+        shouldShow
+        onFadeEnd={mock}
+      />,
+    );
+
+    const image = getByTestId('img');
+
+    rerender(
+      <Placeholder
+        data-testid="img"
+        src={storyblokImage}
+        shouldShow={false}
+        onFadeEnd={mock}
+      />,
+    );
+
+    fireEvent['transitionEnd'](image);
+
+    expect(mock).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
This is a proposal to enhance the implementation of #24.
Here a second state is used to hide the placeholder (remove from DOM) once the transition has ended.
Hope it helps to avoid the additional `div` and even the stale `img` node :)